### PR TITLE
Fix pylint errors

### DIFF
--- a/examples/minimal_usage.py
+++ b/examples/minimal_usage.py
@@ -1,6 +1,8 @@
-from fireflyiii_enricher_core.firefly_client import FireflyClient
+"""Demonstrate minimal usage of :class:`FireflyClient`."""
+
 import os
 from dotenv import load_dotenv
+from fireflyiii_enricher_core.firefly_client import FireflyClient
 
 # Load environment variables from .env.example file
 load_dotenv()

--- a/fireflyiii_enricher_core/firefly_client.py
+++ b/fireflyiii_enricher_core/firefly_client.py
@@ -76,8 +76,10 @@ class FireflyClient:
         try:
             response = requests.get(url, headers=self.headers, timeout=10)
             response.raise_for_status()
-        except requests.RequestException as e:
-            logger.error(f"Failed to fetch transaction {transaction_id}: {e}")
+        except requests.RequestException as err:
+            logger.error(
+                "Failed to fetch transaction %s: %s", transaction_id, err
+            )
             return
 
         payload = {
@@ -87,18 +89,24 @@ class FireflyClient:
         }
 
         try:
-            response = requests.put(url, headers=self.headers, json=payload, timeout=10)
+            response = requests.put(
+                url, headers=self.headers, json=payload, timeout=10
+            )
             response.raise_for_status()
-            logger.info(f"Updated description for transaction {transaction_id}")
-        except requests.RequestException as e:
-            logger.error(f"Update error for {transaction_id}: {e}")
+            logger.info(
+                "Updated description for transaction %s", transaction_id
+            )
+        except requests.RequestException as err:
+            logger.error("Update error for %s: %s", transaction_id, err)
 
     def update_transaction_notes(self, transaction_id, new_notes):
         """Replace the notes for a given transaction."""
         url = f"{self.base_url}/api/v1/transactions/{transaction_id}"
         response = requests.get(url, headers=self.headers, timeout=10)
         if response.status_code != 200:
-            logger.error(f"Failed to fetch transaction {transaction_id}")
+            logger.error(
+                "Failed to fetch transaction %s", transaction_id
+            )
             return
         existing_data = response.json()
         old_description = existing_data.get("data", {}).get("attributes", {}).get("description", "")
@@ -110,22 +118,37 @@ class FireflyClient:
                 "notes": new_notes
             }]
         }
-        response = requests.put(url, headers=self.headers, json=payload, timeout=10)
+        response = requests.put(
+            url, headers=self.headers, json=payload, timeout=10
+        )
         if response.status_code == 200:
-            logger.info(f"Updated notes for transaction {transaction_id}")
+            logger.info(
+                "Updated notes for transaction %s", transaction_id
+            )
         else:
             logger.error(
-                f"Error updating notes for {transaction_id}: {response.status_code} - {response.text}"
+                "Error updating notes for %s: %s - %s",
+                transaction_id,
+                response.status_code,
+                response.text,
             )
 
     def add_tag_to_transaction(self, transaction_id, tag_id):
         """Attach a tag to the specified transaction."""
         url = f"{self.base_url}/api/v1/transactions/{transaction_id}/tags"
         payload = {"tags": [str(tag_id)]}
-        response = requests.post(url, headers=self.headers, json=payload, timeout=10)
+        response = requests.post(
+            url, headers=self.headers, json=payload, timeout=10
+        )
         if response.status_code == 200:
-            logger.info(f"Added tag {tag_id} to transaction {transaction_id}")
+            logger.info(
+                "Added tag %s to transaction %s", tag_id, transaction_id
+            )
         else:
             logger.error(
-                f"Error adding tag {tag_id} to transaction {transaction_id}: {response.status_code} - {response.text}"
+                "Error adding tag %s to transaction %s: %s - %s",
+                tag_id,
+                transaction_id,
+                response.status_code,
+                response.text,
             )

--- a/fireflyiii_enricher_core/matcher.py
+++ b/fireflyiii_enricher_core/matcher.py
@@ -6,6 +6,11 @@ class TransactionMatcher:
     """Helper for aligning CSV records with Firefly transactions."""
 
     @staticmethod
+    def compare_amounts(amount1, amount2):
+        """Return True if the amounts are equal ignoring their sign."""
+        return abs(float(amount1)) == abs(float(amount2))
+
+    @staticmethod
     def match(tx, records):
         """Return CSV records that correspond to the provided transaction."""
         firefly_date = datetime.fromisoformat(tx["date"]).date()
@@ -15,7 +20,7 @@ class TransactionMatcher:
         for record in records:
             csv_date = datetime.strptime(record["date"], "%d-%m-%Y").date()
             csv_amount = float(record["amount"])
-            if csv_date == firefly_date and abs(csv_amount) == abs(firefly_amount):
+            if csv_date == firefly_date and TransactionMatcher.compare_amounts(csv_amount, firefly_amount):
                 matches.append(record)
 
         return matches

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
-# TODO: Implement
+"""Test suite for fireflyiii_enricher_core package."""
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,13 +1,18 @@
+"""Unit tests for :class:`FireflyClient`."""
+
+from unittest.mock import patch
+
 import pytest
 import requests
 
 from fireflyiii_enricher_core.firefly_client import FireflyClient
-from unittest.mock import patch
 
 BASE_URL = "https://demo.firefly.local"
 HEADERS = {"Authorization": "Bearer test-token"}
 
 def fake_response(status_code=200, json_data=None):
+    """Return a minimal fake response object used for mocking."""
+
     class FakeResponse:
         def __init__(self):
             self.status_code = status_code
@@ -24,6 +29,7 @@ def fake_response(status_code=200, json_data=None):
 
 @patch("fireflyiii_enricher_core.firefly_client.requests.get")
 def test_fetch_transactions(mock_get):
+    """Test that transactions are fetched and parsed correctly."""
     mock_get.return_value = fake_response(json_data={
         "data": [{"id": "123", "attributes": {"transactions": [{"description": "test"}]}}],
         "links": {"next": None}
@@ -38,6 +44,7 @@ def test_fetch_transactions(mock_get):
 @patch("fireflyiii_enricher_core.firefly_client.requests.put")
 @patch("fireflyiii_enricher_core.firefly_client.requests.get")
 def test_update_description_success(mock_get, mock_put):
+    """Test updating a description successfully."""
     mock_get.return_value = fake_response()
     mock_put.return_value = fake_response()
 
@@ -45,35 +52,40 @@ def test_update_description_success(mock_get, mock_put):
     client.update_transaction_description("123", "new desc")
 
     mock_put.assert_called_once()
-    args, kwargs = mock_put.call_args
+    _, kwargs = mock_put.call_args
     assert "new desc" in str(kwargs["json"])
 
 @patch("fireflyiii_enricher_core.firefly_client.requests.post")
 def test_add_tag_to_transaction(mock_post):
+    """Test adding a tag to a transaction."""
     mock_post.return_value = fake_response()
 
     client = FireflyClient(BASE_URL, HEADERS)
     client.add_tag_to_transaction("123", tag_id=999)
 
     mock_post.assert_called_once()
-    args, kwargs = mock_post.call_args
+    _, kwargs = mock_post.call_args
     assert kwargs["json"] == {"tags": ["999"]}
 
 @patch("fireflyiii_enricher_core.firefly_client.requests.put")
 @patch("fireflyiii_enricher_core.firefly_client.requests.get")
 def test_update_transaction_notes(mock_get, mock_put):
-    mock_get.return_value = fake_response(json_data={"data": {"id": "123", "attributes": {"description": "desc"}}})
+    """Test updating notes on a transaction."""
+    mock_get.return_value = fake_response(
+        json_data={"data": {"id": "123", "attributes": {"description": "desc"}}}
+    )
     mock_put.return_value = fake_response()
 
     client = FireflyClient(BASE_URL, HEADERS)
     client.update_transaction_notes("123", new_notes="note test")
 
     mock_put.assert_called_once()
-    args, kwargs = mock_put.call_args
+    _, kwargs = mock_put.call_args
     assert kwargs["json"]["transactions"][0]["notes"] == "note test"
 
 @patch("fireflyiii_enricher_core.firefly_client.requests.get")
 def test_fetch_transactions_http_error(mock_get):
+    """Test handling of HTTP errors while fetching transactions."""
     mock_get.return_value = fake_response(status_code=500)
     client = FireflyClient(BASE_URL, HEADERS)
     with pytest.raises(Exception):
@@ -81,14 +93,18 @@ def test_fetch_transactions_http_error(mock_get):
 
 @patch("fireflyiii_enricher_core.firefly_client.requests.get")
 def test_update_transaction_description_http_error_on_get(mock_get):
+    """Update description when GET request fails should be logged."""
     mock_get.return_value = fake_response(status_code=404)
     client = FireflyClient(BASE_URL, HEADERS)
-    client.update_transaction_description("123", "test")  # Should not raise, but log error
+    # Should not raise, only log the error
+    client.update_transaction_description("123", "test")
 
 @patch("fireflyiii_enricher_core.firefly_client.requests.get")
 @patch("fireflyiii_enricher_core.firefly_client.requests.put")
 def test_update_transaction_description_http_error_on_put(mock_put, mock_get):
+    """Update description when PUT request fails should be logged."""
     mock_get.return_value = fake_response()
     mock_put.return_value = fake_response(status_code=500)
     client = FireflyClient(BASE_URL, HEADERS)
-    client.update_transaction_description("123", "test")  # Should not raise, but log error
+    # Should not raise, only log the error
+    client.update_transaction_description("123", "test")


### PR DESCRIPTION
## Summary
- clean up imports and add module docs
- fix logging and line length issues
- expand `TransactionMatcher` to remove pylint warning
- tidy test helpers and add docstrings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6875f1dabc80832ea0ee0ed4652e0587