### PR TITLE
feat: add category retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Python library for enriching Firefly III transactions by updating descriptions
 ## ✨ Features
 
 - ✅ Fetch transactions from Firefly III API
+- 📂 Fetch categories from Firefly III API
 - 📝 Update transaction **descriptions** and **notes**
 - 🏷️ Add tags to transactions
 - 🚫 Filter uncategorized or single-part transactions
@@ -49,6 +50,9 @@ client = FireflyClient(
 
 # Fetch latest withdrawals
 transactions = client.fetch_transactions()
+
+# Fetch categories
+categories = client.fetch_categories()
 
 # Update description
 client.update_transaction_description(123, "New description")

--- a/fireflyiii_enricher_core/firefly_client.py
+++ b/fireflyiii_enricher_core/firefly_client.py
@@ -166,6 +166,23 @@ class FireflyClient:
             page += 1
         return transactions
 
+    def fetch_categories(self, limit: int = 1000) -> List[Dict[str, Any]]:
+        """Retrieve all categories from Firefly III."""
+        url = f"{self.base_url}/api/v1/categories"
+        params = {"limit": limit}
+        page = 1
+        categories: List[Dict[str, Any]] = []
+
+        while True:
+            params["page"] = page
+            response = self._safe_request("get", url, params=params)
+            data = response
+            categories.extend(data["data"])
+            if not data["links"].get("next"):
+                break
+            page += 1
+        return categories
+
     def update_transaction_description(
         self, transaction_id: int, new_description: str
     ) -> Any:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,6 +28,21 @@ def test_fetch_transactions(mock_request: MagicMock) -> None:
 
 
 @patch("fireflyiii_enricher_core.firefly_client.requests.request")
+def test_fetch_categories(mock_request: MagicMock) -> None:
+    """Test fetching paginated categories."""
+    mock_request.side_effect = [
+        MockResponse(
+            {"data": [{"id": "1"}, {"id": "2"}], "links": {"next": "some_url"}}
+        ),
+        MockResponse({"data": [{"id": "3"}], "links": {"next": None}}),
+    ]
+
+    client = FireflyClient(BASE_URL, TOKEN)
+    result = client.fetch_categories()
+    assert len(result) == 3
+
+
+@patch("fireflyiii_enricher_core.firefly_client.requests.request")
 def test_update_description_success(mock_request: MagicMock) -> None:
     """Test successful update of transaction description."""
     mock_request.return_value = MockResponse({})


### PR DESCRIPTION
## Summary
- add FireflyClient.fetch_categories for paginated category retrieval
- document and example category fetching
- test category fetching

## Testing
- `pre-commit run --files fireflyiii_enricher_core/firefly_client.py tests/test_client.py README.md` *(failed: command not found, install blocked)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_688f51b2d20c832e9356b9af99dfb996